### PR TITLE
fix exclusive deck for modded ranks and in general

### DIFF
--- a/Items/Decks/Exclusive Deck.lua
+++ b/Items/Decks/Exclusive Deck.lua
@@ -9,8 +9,10 @@ local exclusive_deck = {
         G.E_MANAGER:add_event(Event({ 
             func = function()
                 local rank = pseudorandom_element(SMODS.Ranks, pseudoseed('exclusive_deck'))
+                local suit = pseudorandom_element(SMODS.Suits, pseudoseed('exclusive_deck'))
+
                 for i = #G.playing_cards, 1, -1 do 
-                    SMODS.change_base(G.playing_cards[i], nil, tostring(rank.id))
+                    assert(SMODS.change_base(G.playing_cards[i], suit.key, rank.key))
                 end
                 return true
             end


### PR DESCRIPTION
For example, ranks of the Showdown mod weren't picked up. I also added the suit because the description of the deck sounds like it was unintended that no suits were changed.